### PR TITLE
Minor VRTKv4 compatibility updates:

### DIFF
--- a/Assets/VRInteraction/Scripts/Editor/VRInteractorEditor.cs
+++ b/Assets/VRInteraction/Scripts/Editor/VRInteractorEditor.cs
@@ -103,7 +103,12 @@ namespace VRInteraction
 			GUIContent hideControllerContent = new GUIContent("Held Hide Controller", "Hide Controllers While Holding Item");
 			hideControllersWhileHolding.boolValue = EditorGUILayout.Toggle(hideControllerContent, hideControllersWhileHolding.boolValue);
 
-			SerializedProperty forceGrabDirection = serializedObject.FindProperty("forceGrabDirection");
+            SerializedProperty triggerHapticPulse = serializedObject.FindProperty("triggerHapticPulse");
+            GUIContent triggerHapticPulseContent = new GUIContent("Trigger Haptic Pulse", "Determines whether or not haptic pulses can be triggered from this VRInteractor. " +
+                "This is desirable for using VRInteractor with VRTK Simulators.");
+            triggerHapticPulse.boolValue = EditorGUILayout.Toggle(triggerHapticPulseContent, triggerHapticPulse.boolValue);
+
+            SerializedProperty forceGrabDirection = serializedObject.FindProperty("forceGrabDirection");
 			GUIContent forceGrabDirectionContent = new GUIContent("Force Grab Direction", "Local Controller Direction, use (1,0,0) for palm or (0,0,1) for forward");
 			EditorGUILayout.PropertyField(forceGrabDirection, forceGrabDirectionContent);
 

--- a/Assets/VRInteraction/Scripts/VRInput.cs
+++ b/Assets/VRInteraction/Scripts/VRInput.cs
@@ -725,9 +725,10 @@ namespace VRInteraction
 		public bool isBY_Pressed { get { return _menuPressedFlag; } }
 		public bool isAX_Pressed { get { return _AX_PressedFlag; } }
 
-		virtual protected void SendMessageToInteractor(string message)
-		{
-			SendMessage("InputReceived", message, SendMessageOptions.DontRequireReceiver);
+        //Made public so that it could be called by VRTKv4 events
+        virtual public void SendMessageToInteractor(string message)
+        {
+            SendMessage("InputReceived", message, SendMessageOptions.DontRequireReceiver);
 		}
 
 		protected void TriggerClicked()

--- a/Assets/VRInteraction/Scripts/VRInteractor.cs
+++ b/Assets/VRInteraction/Scripts/VRInteractor.cs
@@ -30,6 +30,7 @@ namespace VRInteraction
 		public bool useHoverLine;
 		public Material hoverLineMat;
 		public Transform _vrRigRoot;
+        public bool triggerHapticPulse = true;
 
 		protected VRInteractableItem _hoverItem;
 		protected VRInteractableItem _heldItem;
@@ -75,7 +76,7 @@ namespace VRInteraction
 			{
 				if (_highlighting == value) return;
 				_highlighting = value;
-				if (_highlighting)
+				if (_highlighting && triggerHapticPulse)
 				{
 					TriggerHapticPulse(500);
 				}
@@ -174,6 +175,8 @@ namespace VRInteraction
 		}
 		virtual public void TriggerHapticPulse(int frames)
 		{
+            if (!triggerHapticPulse) return;
+
 			#if Int_SteamVR && !Int_SteamVR2
 			if (vrInput.isSteamVR())
 			{


### PR DESCRIPTION
-Made VRInput.SendMessageToInteractor public for use with VRTKv4 events
-Added TriggerHapticPulse boolean to VRInteractor for disabling of haptic pulses.

To use VRTKv4 with VRI, just have your desired VRTKv4 event call VRInput.SendMessageToInteractor with one of the following strings:
- "PICKUP_DROP"
- "PICKUP_DROPReleased"
- "ACTION"
- "ACTIONReleased"